### PR TITLE
@bem-react/core: Not pass matched props from withBemMod

### DIFF
--- a/packages/core/core.tsx
+++ b/packages/core/core.tsx
@@ -23,9 +23,13 @@ export function withBemMod<P extends IClassNameProps>(blockName: string, mod: No
         function BemMod(props: Dictionary<P>) {
             const entity = cn(blockName);
 
+            // @ts-ignore
+            const defaultProps = Object.assign({}, WrappedComponent({}).props);
+            Object.keys(defaultProps).forEach(key => (defaultProps[key] === undefined || key === 'className') && delete defaultProps[key]);
+
             if (Object.keys(mod).every(key => props[key] === mod[key])) {
                 const nextClassName = classnames(entity(mod), props.className);
-                const nextProps = Object.assign({}, props, { className: nextClassName });
+                const nextProps = Object.assign({}, props, defaultProps, { className: nextClassName });
 
                 if (__DEV__) {
                     setDisplayName(BemMod, {

--- a/packages/core/test/withBemMod.test.tsx
+++ b/packages/core/test/withBemMod.test.tsx
@@ -9,15 +9,26 @@ import { withBemMod, IClassNameProps } from '../core';
 const getClassNameFromSelector = (Component: React.ReactElement<any>, selector: string = 'div') =>
     mount(Component).find(selector).prop('className');
 
+const getTypeFromSelector = (Component: React.ReactElement<any>, selector: string = 'button') =>
+    mount(Component).find(selector).prop('type');
+
 interface IPresenterProps extends IClassNameProps {
     theme?: 'normal';
     view?: 'default';
 }
 
+interface IButtonProps extends IClassNameProps {
+    type: string;
+}
+
 const presenter = cn('Presenter');
+const button = cn('Button');
 
 const Presenter: React.SFC<IPresenterProps> = ({ className }) =>
     <div className={presenter({}, [className])} />;
+
+const Button: React.SFC<IButtonProps> = ({ type = 'button', className}) =>
+    <button className={button({}, [className])} type={type} />;
 
 describe('withBemMod', () => {
     it('should not affect CSS class with empty object', () => {
@@ -39,5 +50,11 @@ describe('withBemMod', () => {
         const WBCM = withBemMod<IPresenterProps>(presenter(), { theme: 'normal' })(Presenter);
         expect(getClassNameFromSelector(<WBCM className="Additional" />))
             .eq('Presenter Additional');
+    });
+
+    it('should not pass matched props from withBemMod', () => {
+        const WBCM = withBemMod<IButtonProps>(button(), { type: 'link' })(Button);
+        expect(getTypeFromSelector(<WBCM className="Additional" type="link" />))
+            .eq('button');
     });
 });


### PR DESCRIPTION
- Реализовал
- Добавил тест

Не знал, как получить доступ к пропсам `WrappedComponent`, в итоге сделал через `Object.assign({}, WrappedComponent({}).props)`, но TS победить не смог
```
[ts] Cannot invoke an expression whose type lacks a call signature. Type 'ComponentType<P>' has no compatible call signatures. [2349]
```
upd: Нашел немного инфы [здесь](https://medium.com/@franleplant/react-higher-order-components-in-depth-cf9032ee6c3e), называется это Inheritance Inversion

resolves #344 