### PR TITLE
refactor(core): remove isApplied flag and set name for mod body

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -178,9 +178,9 @@ To help your debug "@bem-react/core" support development mode.
 For `<Button type="link" theme="action">Hello</Button>` (from the **Example** above), React DevTools will show:
 
 ```html
-<WithBemMod(Button)[theme:action][enabled] ...>
-  <WithBemMod(Button)[type:link][enabled] ...className="Button Button_theme_action">
+<WithBemMod(Button)[theme:action] ...>
+  <WithBemMod(Button)[type:link] className="Button Button_theme_action" ...>
     <a className="Button Button_type_link Button_theme_action">Hello</a>
-  </WithBemMod(Button)[type:link][enabled]>
-</WithBemMod(Button)[theme:action][enabled]>
+  </WithBemMod(Button)[type:link]>
+</WithBemMod(Button)[theme:action]>
 ```


### PR DESCRIPTION
Удалил флаг `isApplied`, т.к. `displayName` является статическим свойством, то этот флаг применялся на все модификаторы данного типа, вне зависимости от того, включен он или нет.
Так же добавил `displayName` для модификатора с телом.