### PR TITLE
chore(core): sync react version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "@bem-react/classnames": "^1.3.5"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.8.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
```
npm WARN @bem-react/di@2.0.1 requires a peer of react@^16.8.0 but none is installed. You must install peer dependencies yourself.
npm WARN @bem-react/core@2.0.1 requires a peer of react@^16.0.0 but none is installed. You must install peer dependencies yourself.
```