### PR TITLE
feat(di): set components via object literal

### DIFF
--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -48,6 +48,24 @@ registry.set('Header', Header)
 registry.set('Footer', Footer)
 ```
 
+or
+
+```ts
+registry.fill({
+  Header,
+  Footer,
+})
+```
+
+or
+
+```ts
+registry.fill({
+  'id-1': Header,
+  'id-2': Footer,
+})
+```
+
 3. Export the App version with its registry of components:
 
 ```ts

--- a/packages/di/di.tsx
+++ b/packages/di/di.tsx
@@ -104,6 +104,20 @@ export class Registry {
   }
 
   /**
+   * Set react components in registry via object literal.
+   *
+   * @param componentsSet set of valid react components
+   */
+  fill(componentsSet: IRegistryComponents) {
+    this.components = {
+      ...this.components,
+      ...componentsSet,
+    }
+
+    return this
+  }
+
+  /**
    * Get react component from registry by id.
    *
    * @param id component id

--- a/packages/di/test/di.test.tsx
+++ b/packages/di/test/di.test.tsx
@@ -31,6 +31,23 @@ describe('@bem-react/di', () => {
       expect(registry.get('id-2')).to.eq(Component2)
     })
 
+    it('should fill components via object literal', () => {
+      const registry = new Registry({ id: 'registry' })
+      const Component1 = () => null
+      const Component2 = () => <span />
+
+      registry.fill({
+        Component1,
+        Component2,
+      })
+
+      const snapshot: any = {}
+      snapshot['Component1'] = Component1
+      snapshot['Component2'] = Component2
+
+      expect(registry.snapshot()).to.eql(snapshot)
+    })
+
     it('should return list of components', () => {
       const registry = new Registry({ id: 'registry' })
       const Component1 = () => null


### PR DESCRIPTION
Hi there!

It should be cool if we could fill a registry with components via object literal

```
registry.fill({
    ReviewsDigest,
    ReviewsCards,
    AllReviewsButton,
    MoreItem,
    Review,
    ReviewsTitle,
    RatingLine,
    AuthorName,
    AuthorLevel,
    ReviewText,
    Link,
    Button,
    KeyPhraseButton,
    Wrapper,
    Scroller,
    Reactions,
    AuthorizationNeeded,
    AuthorizationNeededRegisterButton,
    AuthorizationNeededLoginButton
});
```
instead of
```
registry.set('ReviewsDigest', ReviewsDigest);
registry.set('ReviewsCards', ReviewsCards);
registry.set('AllReviewsButton', AllReviewsButton);
registry.set('MoreItem', MoreItem);
registry.set('Review', Review);
registry.set('ReviewsTitle', ReviewsTitle);
registry.set('RatingLine', RatingLine);
registry.set('AuthorName', AuthorName);
registry.set('AuthorLevel', AuthorLevel);
registry.set('ReviewText', ReviewText);
registry.set('Link', Link);
registry.set('Button', Button);
registry.set('KeyPhraseButton', KeyPhraseButton);
registry.set('Wrapper', Wrapper);
registry.set('Scroller', Scroller);
registry.set('Reactions', Reactions);
registry.set('AuthorizationNeeded', AuthorizationNeeded);
registry.set('AuthorizationNeededRegisterButton', AuthorizationNeededRegisterButton);
registry.set('AuthorizationNeededLoginButton', AuthorizationNeededLoginButton);
```