### PR TITLE
fix: simple mods optimization in compose

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -288,6 +288,22 @@ export const App = () => {
 }
 ```
 
+## Simple modifiers (only CSS classes)
+
+In most cases you need change only CSS class. This mode doesn't pass modififer value to props.
+It doesn't create React wrappers for component, that's way more optimal.
+
+```tsx
+import React from 'react'
+import { cnBlock } from '../Block'
+
+export interface BlockModProps {
+  simplemod?: boolean
+}
+
+export const withSimpleMod = createClassNameModifier<BlockModProps>(cnBlock(), { simplemod: true })
+```
+
 ## Debug
 
 To help your debug "@bem-react/core" support development mode.

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -50,10 +50,15 @@ export type Enhance<T extends IClassNameProps> = (
 
 type Dictionary<T = any> = { [key: string]: T }
 
+type withBemModOptions = {
+  __passToProps: boolean
+  __simple: boolean
+}
+
 export function withBemMod<T, U extends IClassNameProps = {}>(
   blockName: string,
   mod: NoStrictEntityMods,
-  enhance?: Enhance<T & U>,
+  enhance?: Enhance<T & U> | withBemModOptions,
 ) {
   let entity: ClassNameFormatter
   let entityClassName: string
@@ -93,7 +98,7 @@ export function withBemMod<T, U extends IClassNameProps = {}>(
           // Replace first entityClassName for remove duplcates from className.
           .replace(`${entityClassName} `, '')
 
-        if (enhance !== undefined) {
+        if (typeof enhance === 'function') {
           if (ModifiedComponent === undefined) {
             ModifiedComponent = enhance(WrappedComponent as any)
 
@@ -127,11 +132,35 @@ export function withBemMod<T, U extends IClassNameProps = {}>(
     return BemMod
   }
 
-  withMod.blockName = blockName
-  withMod.mod = mod
-  withMod.isSimple = !enhance
+  const { __passToProps = true, __simple = false } = (enhance as withBemModOptions) || {}
+
+  const keys = Object.keys(mod)
+  const isSimple = !enhance && keys.length === 1
+  const name = keys[0]
+  const value = mod[keys[0]]
+
+  if (__DEV__) {
+    if (isSimple) {
+      console.warn(
+        `${blockName}[${name}:${value}] is simple, replace "withBemMod" -> "createClassNameModifier" `,
+      )
+    }
+  }
+
+  withMod.__isSimple = isSimple || __simple
+
+  if (withMod.__isSimple) {
+    withMod.__blockName = blockName
+    withMod.__mod = name
+    withMod.__value = value
+    withMod.__passToProps = __passToProps
+  }
 
   return withMod
+}
+
+export function createClassNameModifier<T>(blockName: string, mod: NoStrictEntityMods) {
+  return withBemMod<T>(blockName, mod, { __passToProps: false, __simple: true })
 }
 
 export type ExtractProps<T> = T extends ComponentType<infer K> ? { [P in keyof K]: K[P] } : never
@@ -141,43 +170,46 @@ export type Composition<T> = <U extends ComponentType<any>>(
   fn: U,
 ) => StatelessComponent<JSX.LibraryManagedAttributes<U, ExtractProps<U>> & T>
 
-type AllMods = {
-  [key: string]: string[]
-}
+function composeSimple(mods: any[]) {
+  const { __blockName } = mods[0]
+  const allMods: Record<string, string[]> = {}
+  const allModsPassProps: Record<string, boolean[]> = {}
 
-export function composeSimple(mods: any[]) {
-  const { blockName } = mods[0]
-  const allMods: AllMods = {}
+  const entity = cn(__blockName)
 
-  const entity = cn(blockName)
+  for (let { __mod, __value, __passToProps } of mods) {
+    allMods[__mod] = allMods[__mod] || []
+    // для оптимизации поиска вводим простой массив вместо объекта
+    allModsPassProps[__mod] = allModsPassProps[__mod] || []
 
-  for (let index = 0; index < mods.length; index++) {
-    const { mod } = mods[index]
-
-    Object.keys(mod).forEach((key) => {
-      allMods[key] = allMods[key] || []
-
-      allMods[key].push(mod[key])
-    })
+    allMods[__mod].push(__value)
+    allModsPassProps[__mod].push(__passToProps)
   }
+
   const modNames = Object.keys(allMods)
 
-  return (Base: any) => {
-    return (props: any) => {
-      const modifiers = modNames.reduce((acc: NoStrictEntityMods, key: string) => {
+  return (Base: ComponentType<any>) => {
+    return (props: Record<string, any>) => {
+      const modifiers: NoStrictEntityMods = {}
+      const newProps: any = { ...props }
+
+      for (let key of modNames) {
         const modValues = allMods[key]
-        const propValue = (props as any)[key]
+        const propValue = props[key]
 
-        if (modValues.includes(propValue)) {
-          acc[key] = propValue
+        const foundInValues = modValues.indexOf(propValue)
+        if (foundInValues !== -1) {
+          modifiers[key] = propValue
+          // если стоит флаг __passToProps = false, то не добавляем в пропсы
+          if (!allModsPassProps[key][foundInValues]) {
+            delete newProps[key]
+          }
         }
+      }
 
-        return acc
-      }, {})
+      newProps.className = entity(modifiers, [props.className])
 
-      const className = entity(modifiers, [props.className])
-
-      return createElement(Base, { ...props, className })
+      return createElement(Base, newProps)
     }
   }
 }
@@ -256,12 +288,10 @@ export function compose() {
   // Use arguments instead of rest-arguments to get faster and more compact code.
   const fns: any[] = [].slice.call(arguments)
 
-  const simple = []
+  const simple: any[] = []
   const enhanced = []
-  for (let index = 0; index < fns.length; index++) {
-    const f = fns[index]
-
-    f.isSimple ? simple.push(f) : enhanced.push(f)
+  for (let f of fns) {
+    f.__isSimple ? simple.push(f) : enhanced.push(f)
   }
 
   const oprimizedFns = simple.length ? [composeSimple(simple), ...enhanced] : enhanced

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -139,14 +139,6 @@ export function withBemMod<T, U extends IClassNameProps = {}>(
   const name = keys[0]
   const value = mod[keys[0]]
 
-  if (__DEV__) {
-    if (isSimple) {
-      console.warn(
-        `${blockName}[${name}:${value}] is simple, replace "withBemMod" -> "createClassNameModifier" `,
-      )
-    }
-  }
-
   withMod.__isSimple = isSimple || __simple
 
   if (withMod.__isSimple) {
@@ -189,7 +181,7 @@ function composeSimple(mods: any[]) {
   const modNames = Object.keys(allMods)
 
   return (Base: ComponentType<any>) => {
-    return (props: Record<string, any>) => {
+    function SimpleComposeWrapper(props: Record<string, any>) {
       const modifiers: NoStrictEntityMods = {}
       const newProps: any = { ...props }
 
@@ -211,6 +203,20 @@ function composeSimple(mods: any[]) {
 
       return createElement(Base, newProps)
     }
+    if (__DEV__) {
+      const allModsFormatted = Object.keys(allMods)
+        .map((key) => {
+          const mods
+            = allMods[key].length > 3 ? ` ${allMods[key].length} mods` : allMods[key].join('|')
+
+          return `[${key}:${mods}]`
+        })
+        .join(',')
+
+      SimpleComposeWrapper.displayName = `SimpleComposeWrapper ${allModsFormatted}`
+    }
+
+    return SimpleComposeWrapper
   }
 }
 

--- a/packages/core/test/compose.test.tsx
+++ b/packages/core/test/compose.test.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ComponentType } from 'react'
 import { mount } from 'enzyme'
 
-import { compose, composeU } from '../core'
+import { compose, composeU, withBemMod } from '../core'
 
 type BaseProps = {
   text: string
@@ -23,13 +23,19 @@ type SizeAProps = {
   size?: 'a'
 }
 
+type SimpleProps = {
+  simple?: true
+}
+
 const Component: FC<BaseProps> = ({ children }) => <div>{children}</div>
+const withSimpleCompose = withBemMod<SimpleProps>('EnhancedComponent', { simple: true })
 const withHover = (Wrapped: ComponentType<any>) => (props: HoveredProps) => <Wrapped {...props} />
 const withThemeA = (Wrapped: ComponentType<any>) => (props: ThemeAProps) => <Wrapped {...props} />
 const withThemeB = (Wrapped: ComponentType<any>) => (props: ThemeBProps) => <Wrapped {...props} />
 const withSizeA = (Wrapped: ComponentType<any>) => (props: SizeAProps) => <Wrapped {...props} />
 
 const EnhancedComponent = compose(
+  withSimpleCompose,
   withHover,
   withSizeA,
   composeU(withThemeA, withThemeB),
@@ -46,5 +52,9 @@ describe('compose', () => {
 
   test('should compile component with hovered true', () => {
     mount(<EnhancedComponent hovered text="" />)
+  })
+
+  test('should compile component with simple mod', () => {
+    mount(<EnhancedComponent theme="b" simple text="" />)
   })
 })


### PR DESCRIPTION
Если модификатор простой (т.е. нет 3 аргумента в withBemMod), то не имеет смысла оборачивать компонент, можно просто добавить необходимый класс.