### PR TITLE
fix(di): fixed merge of registries with same id

### DIFF
--- a/packages/di/di.tsx
+++ b/packages/di/di.tsx
@@ -32,7 +32,7 @@ export function withRegistry() {
 
               for (let i = 0; i < registries.length; i++) {
                 const registry = registries[i]
-                const overrides = contextRegistries[registry.id]
+                const overrides = providedRegistries[registry.id]
                 // eslint-disable-next-line no-nested-ternary
                 providedRegistries[registry.id] = registry.overridable
                   ? overrides

--- a/packages/di/test/di.test.tsx
+++ b/packages/di/test/di.test.tsx
@@ -494,6 +494,36 @@ describe('@bem-react/di', () => {
       })
     })
 
+    test('should merge all provided registries', () => {
+      const registryA = new Registry({ id: 'TestRegistry' })
+      const ElementA = (_props: ICommonProps) => <span>content</span>
+
+      registryA.set('ElementA', ElementA)
+
+      const ElementAPresenter: React.FC<ICommonProps> = () => (
+        <ComponentRegistryConsumer id="TestRegistry">
+          {({ ElementA }) => <ElementA />}
+        </ComponentRegistryConsumer>
+      )
+
+      const ElementB = (_props: ICommonProps) => <span>content of elementB</span>
+      const registryB = new Registry({ id: 'TestRegistry' })
+
+      registryB.set('ElementB', ElementB)
+
+      const ElementBPresenter: React.FC<ICommonProps> = () => (
+        <ComponentRegistryConsumer id="TestRegistry">
+          {({ ElementB }) => <ElementB />}
+        </ComponentRegistryConsumer>
+      )
+
+      const AppA = withRegistry(registryA, registryB)(ElementAPresenter)
+      const AppB = withRegistry(registryA, registryB)(ElementBPresenter)
+
+      expect(render(<AppA />).text()).toEqual('content')
+      expect(render(<AppB />).text()).toEqual('content of elementB')
+    })
+
     describe('hooks', () => {
       test('should provide registry with useRegistries', () => {
         const compositorRegistry = new Registry({ id: 'Compositor' })


### PR DESCRIPTION
Решение проблемы: при передаче в withRegistry нескольких реестров с одним id на выходе получаем только последний переданный реестр, вместо смерженного.