### PR TITLE
fix(build): fix minification issues in classname pkg

### DIFF
--- a/scripts/rollup/terser.config.js
+++ b/scripts/rollup/terser.config.js
@@ -5,7 +5,7 @@ const nameCache = {}
 module.exports.getTerserConfig = () => ({
   compress: {
     arrows: false,
-    booleans_as_integers: true,
+    booleans_as_integers: false,
     booleans: true,
     collapse_vars: true,
     comparisons: true,


### PR DESCRIPTION
We found an issue in the `.min` build of `@bem-react/classname` package.

`classname.development.js`:
```js
cn('block')({ mod: '1' }) // block__mod_1
```

`classname.production.min.js`:
```js
cn('block')({ mod: '1' }) // block__mod
```

This happens because of `booleans_as_integers` terser option.

This expression:
```js
if (modVal === true) {
    className += modPrefix + k;
} else {
    <...>
}
```

Transforms to:
```js
1 == p ? v += u + s : <...>
```

It's impossible to use mod values `'1'` or `1` with such transform.

Full diff with and without `booleans_as_integers` option: https://www.diffchecker.com/2XzvNEZg
