### PR TITLE
Add correct overloads for cn formatter

### DIFF
--- a/packages/classname/classname.ts
+++ b/packages/classname/classname.ts
@@ -18,15 +18,12 @@ export type ClassNameInitilizer = (blockName: string, elemName?: string) => Clas
 /**
  * BEM Entity className formatter.
  */
-declare function classNameFormatter(): string
-declare function classNameFormatter(elemNameOrBlockMods: null, elemMix: ClassNameList): string
-declare function classNameFormatter(
-  elemNameOrBlockMods: NoStrictEntityMods | string,
-  elemModsOrBlockMix?: NoStrictEntityMods | ClassNameList | null,
-  elemMix?: ClassNameList,
-): string
-
-export type ClassNameFormatter = typeof classNameFormatter
+export interface ClassNameFormatter {
+  (): string
+  (mods?: NoStrictEntityMods | null, mix?: ClassNameList): string
+  (elemName: string, elemMix?: ClassNameList): string
+  (elemName: string, elemMods?: NoStrictEntityMods | null, elemMix?: ClassNameList): string
+}
 
 /**
  * Settings for the naming convention.


### PR DESCRIPTION
В последней версии не все сценарии работают правильно:
Проверял на вывод типов вот это:
```typescript
const cnBlock = cn('Test')

// correct
cnBlock()
cnBlock(undefined) // <- в @bem-react/classname@1.5.11 ошибка
cnBlock(undefined, undefined) // <- в @bem-react/classname@1.5.11 ошибка
cnBlock(undefined, ['mix']) // <- в @bem-react/classname@1.5.11 ошибка
cnBlock(null) // <- в @bem-react/classname@1.5.11 ошибка
cnBlock(null, undefined) // <- в @bem-react/classname@1.5.11 ошибка
cnBlock(null, ['mix'])
cnBlock({ mod: 'val' })
cnBlock({ mod: 'val' }, undefined)
cnBlock({ mod: 'val' }, ['mix'])
cnBlock('Elem')
cnBlock('Elem', undefined)
cnBlock('Elem', undefined, undefined)
cnBlock('Elem', undefined, ['mix'])
cnBlock('Elem', null)
cnBlock('Elem', null, undefined)
cnBlock('Elem', null, ['mix'])
cnBlock('Elem', { mod: 'val' })
cnBlock('Elem', { mod: 'val' }, undefined)
cnBlock('Elem', { mod: 'val' }, ['mix'])
cnBlock('Elem', ['mix'])

// incorrect
// @ts-expect-error
cnBlock(undefined, null)
// @ts-expect-error
cnBlock(null, null)
// @ts-expect-error
cnBlock('Elem', undefined, null)
// @ts-expect-error
cnBlock('Elem', null, null)
// @ts-expect-error
cnBlock('Elem', '')
// @ts-expect-error
cnBlock('Elem', {}, {})
```