### PR TITLE
fix: set booleans_as_integers to false in terser config

### DIFF
--- a/scripts/rollup/terser.config.js
+++ b/scripts/rollup/terser.config.js
@@ -5,7 +5,7 @@ const nameCache = {}
 module.exports.getTerserConfig = () => ({
   compress: {
     arrows: false,
-    booleans_as_integers: true,
+    booleans_as_integers: false,
     booleans: true,
     collapse_vars: true,
     comparisons: true,


### PR DESCRIPTION
## Summary

Исправляет опцию `booleans_as_integers` в конфиге terser — при значении `true` ломалась логика пакета `@bem-react/classname`.
